### PR TITLE
SEO titles: prefer "Old Norse" over "Cleasby & Vigfusson"

### DIFF
--- a/src/components/LetterHeader/__snapshots__/LetterHeader.test.js.snap
+++ b/src/components/LetterHeader/__snapshots__/LetterHeader.test.js.snap
@@ -13,7 +13,7 @@ exports[`LetterHeader component Matches snapshot 1`] = `
   <small
     className="subHeading"
   >
-    Cleasby & Vigfusson Dictionary - Letter 
+    Old Norse Dictionary - Letter 
     S
   </small>
   <p>

--- a/src/components/LetterHeader/index.js
+++ b/src/components/LetterHeader/index.js
@@ -5,7 +5,7 @@ export default function LetterLink({ letter, count }) {
    <header className={styles.section}>
     <h1 className={styles.title}>Letter {letter.toUpperCase()}</h1>
     <small className={styles.subHeading}>
-      Cleasby & Vigfusson Dictionary - Letter {letter.toUpperCase()}
+      Old Norse Dictionary - Letter {letter.toUpperCase()}
     </small>
     <p>Old Norse words starting with letter {letter.toUpperCase()}</p>
     <small className={styles.count}>Total of {count} words</small>

--- a/src/components/WordDefinition/__snapshots__/WordDefinition.test.js.snap
+++ b/src/components/WordDefinition/__snapshots__/WordDefinition.test.js.snap
@@ -13,7 +13,7 @@ exports[`WordDefinition component Matches snapshot 1`] = `
     <small
       className="subHeading"
     >
-      Cleasby & Vigfusson Dictionary - 
+      Old Norse Dictionary - 
       af-burðr
     </small>
     <p>

--- a/src/components/WordDefinition/index.js
+++ b/src/components/WordDefinition/index.js
@@ -13,7 +13,7 @@ export default function WordDefinition({ data, abbreviations }) {
         <h1 lang="non">{capitalize(word)}</h1>
 
         <small className={styles.subHeading}>
-          Cleasby & Vigfusson Dictionary - {word.toLowerCase()}
+          Old Norse Dictionary - {word.toLowerCase()}
         </small>
         <p>Possible runic inscription in <em>Younger Futhark:</em>
           <span className={styles.rune}>{ lettersToRunes(word) }</span>

--- a/src/lib/utils/seo.js
+++ b/src/lib/utils/seo.js
@@ -7,7 +7,7 @@ import { capitalize } from 'lib/utils/strings'
 export const getSeo = (content = null, type = null) => {
   if (type === 'word') {
     return {
-      title: `Cleasby & Vigfusson Dictionary - ${capitalize(content.word)}`,
+      title: `Old Norse Dictionary - ${capitalize(content.word)}`,
       description: `Meaning of Old Norse word "${content.word.toLowerCase()}"`,
     }
   }
@@ -15,14 +15,14 @@ export const getSeo = (content = null, type = null) => {
   if (type === 'letter') {
     const firstWords = content.slice(0, 4).map((word) => word.word.toLowerCase())
     return {
-      title: `Cleasby & Vigfusson - Old Norse words starting with letter ${firstWords[0].charAt(0).toUpperCase()}`,
+      title: `Old Norse words starting with letter ${firstWords[0].charAt(0).toUpperCase()}`,
       description: `Meanings of Old Norse words starting with "${firstWords[0].charAt(0).toUpperCase()}", such as ${joinWithConj(firstWords)}`,
     }
   }
 
   // Default tags.
   return {
-    title: 'Cleasby & Vigfusson Dictionary - Old Norse to English',
+    title: 'Old Norse Dictionary - Old Norse to English',
     description: 'Over 35 000 Old Norse words with dictionary definitions',
   }
 }

--- a/tests/unit/lib/utils/seo.test.js
+++ b/tests/unit/lib/utils/seo.test.js
@@ -43,7 +43,7 @@ describe('SEO / meta tags tests', () => {
 
   test('Handles "word" seo fields', () => {
     const expected = {
-      title: 'Cleasby & Vigfusson Dictionary - Af-búð',
+      title: 'Old Norse Dictionary - Af-búð',
       description: 'Meaning of Old Norse word "af-búð"',
     }
 
@@ -54,7 +54,7 @@ describe('SEO / meta tags tests', () => {
 
   test('Handles "letter" seo fields', () => {
     const expected = {
-      title: 'Cleasby & Vigfusson - Old Norse words starting with letter A',
+      title: 'Old Norse words starting with letter A',
       description: 'Meanings of Old Norse words starting with "A", such as af-burðr, af-búð, af-dalr and af-deilingr',
     }
 
@@ -65,7 +65,7 @@ describe('SEO / meta tags tests', () => {
 
   test('Handles default response', () => {
     const expected = {
-      title: 'Cleasby & Vigfusson Dictionary - Old Norse to English',
+      title: 'Old Norse Dictionary - Old Norse to English',
       description: 'Over 35 000 Old Norse words with dictionary definitions',
     }
 

--- a/tests/unit/pages/__snapshots__/letter.test.js.snap
+++ b/tests/unit/pages/__snapshots__/letter.test.js.snap
@@ -487,7 +487,7 @@ Array [
       <small
         className="subHeading"
       >
-        Cleasby & Vigfusson Dictionary - Letter 
+        Old Norse Dictionary - Letter 
         E
       </small>
       <p>

--- a/tests/unit/pages/__snapshots__/word.test.js.snap
+++ b/tests/unit/pages/__snapshots__/word.test.js.snap
@@ -495,7 +495,7 @@ Array [
         <small
           className="subHeading"
         >
-          Cleasby & Vigfusson Dictionary - 
+          Old Norse Dictionary - 
           völva
         </small>
         <p>


### PR DESCRIPTION
The sister project of this site "Old Icelandic Dictionary" seems to fare much better SEO-wise. It seems that generic "Old Icelandic Dictionary" is more approachable in search results than "Cleasby & Vigfusson Dictionary", even if "Old Norse" is often mentioned. In general, readers of ON seem to appreciate Cleasby & Vigfusson book over the Zoega one, so this should be more a question of people not finding it in search engines.

Keep main mentions of "Cleasby & Vigfusson" to be transparent about the data source, but use "Old Norse Dictionary" in SEO titles & matching lines in content. Should make it more generic in terms of search result, which may help in generic "x in old norse" queries

Fixes #239