### PR TITLE
Search endpoint: limit memory via vercel.json

### DIFF
--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -2,14 +2,6 @@ import { getAllWords } from 'lib/services/dictionary'
 import { Criteria, searchDictionary } from 'lib/services/search';
 import { NextApiRequest, NextApiResponse } from 'next';
 
-export const config = {
-  /**
-   * Default Vercel memory allocation is a bit too generous,
-   * easily multiplying GBh usage per momth. Limit it.
-   */
-  memory: 512, // Half of default 1GB.
-}
-
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (!req.query.search || !req.query.criteria) {
     return res.status(422).json({ message: 'Missing search term or criteria' })

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+    "functions": {
+      "api/search.ts": {
+        "memory": 512
+      }
+    }
+  }


### PR DESCRIPTION
Previously exported config via the route, but Vercel did not use it. Apparently there is overlap in some values of vercel.json functions & exported config, but not all values can be used in there. For example, runtime can be configured via both of them.

Relates to #478 